### PR TITLE
Fixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1370,18 +1370,12 @@ public class MagicSpells extends JavaPlugin {
 	public static void sendMessageAndFormat(String message, LivingEntity livingEntity, String[] args, String... replacements) {
 		if (!(livingEntity instanceof Player)) return;
 		if (message == null || message.isEmpty()) return;
-
 		//Do var replacements
 		message = doArgumentAndVariableSubstitution(message, (Player) livingEntity, args);
-
 		//Format
 		message = formatMessage(message, replacements);
-
 		//Send messages
-		for (String msg : message.split("\n")) {
-			if (msg.isEmpty()) continue;
-			livingEntity.sendMessage(Util.getMiniMessage(getTextColor() + msg));
-		}
+		livingEntity.sendMessage(Util.getMiniMessage(getTextColor() + message));
 	}
 
 	public static void sendMessage(Player player, String message) {

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1614,6 +1614,15 @@ public class MagicSpells extends JavaPlugin {
 		try {
 			File folder = new File(plugin.getDataFolder(), "errors");
 			if (!folder.exists()) folder.mkdir();
+
+			// Delete old errors if the folder is too many.
+			File[] oldErrors = folder.listFiles();
+			if (oldErrors != null && oldErrors.length >= 50) {
+				for (File file : oldErrors) {
+					file.delete();
+				}
+			}
+
 			writer = new PrintWriter(new File(folder, System.currentTimeMillis() + ".txt"));
 			Throwable t = ex;
 			while (t != null) {

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasMarkCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasMarkCondition.java
@@ -25,7 +25,7 @@ public class HasMarkCondition extends Condition {
 	@Override
 	public boolean check(LivingEntity livingEntity) {
 		if (!(livingEntity instanceof Player)) return false;
-		return spell.getMarks().containsKey(livingEntity.getName().toLowerCase());
+		return spell.getMarks().containsKey(livingEntity.getUniqueId());
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ResourcePackSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ResourcePackSpell.java
@@ -34,7 +34,7 @@ public class ResourcePackSpell extends TargetedSpell {
 	public void initialize() {
 		super.initialize();
 
-		if (hash.length() != HASH_LENGTH) {
+		if (hash != null && hash.length() != HASH_LENGTH) {
 			MagicSpells.error("ResourcePackSpell '" + internalName + "' has an incorrect hash length defined: '" + hash.length() + "' / " + HASH_LENGTH + ".");
 		}
 	}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/CurrentHealthVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/CurrentHealthVariable.java
@@ -2,6 +2,7 @@ package com.nisovin.magicspells.variables.meta;
 
 import org.bukkit.entity.Player;
 
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.PlayerNameUtils;
 import com.nisovin.magicspells.variables.variabletypes.MetaVariable;
 
@@ -17,7 +18,11 @@ public class CurrentHealthVariable extends MetaVariable {
 	@Override
 	public void set(String player, double amount) {
 		Player p = PlayerNameUtils.getPlayerExact(player);
-		if (p != null) p.setHealth(amount);
+		if (p == null) return;
+		double max = Util.getMaxHealth(p);
+		if (amount < 0) amount = 0;
+		if (amount > max) amount = max;
+		p.setHealth(amount);
 	}
 
 }


### PR DESCRIPTION
* Clamp current health meta variable.
* Removes unnecessary newline split on `MagicSpells#sendMessageAndFormat`.
* Deletes contents of the `errors` folder if there are more than 50 error files in it.
* Fixed `hasmark` modifier condition.